### PR TITLE
ci: add workflow to create project cards from new github issues

### DIFF
--- a/.github/workflows/create-card-from-issue.yml
+++ b/.github/workflows/create-card-from-issue.yml
@@ -5,13 +5,13 @@ on:
     types: [ opened ]
     
 env:
-  GITHUB_REPO_PROJECT_NAME: GHA Test
+  GITHUB_REPO_PROJECT_NAME: Testing
   COLUMN_FOR_NEW_CARDS: To do
 
 
 name: Create project card from issue
 jobs:
-  build:
+  create-card:
     runs-on: ubuntu-latest
     steps:
       - name: Create or Update Project Card

--- a/.github/workflows/create-card-from-issue.yml
+++ b/.github/workflows/create-card-from-issue.yml
@@ -2,7 +2,7 @@
 
 on: 
   issues:
-    types: [ opened ]
+    types: [ opened, edited ]
     
 env:
   GITHUB_REPO_PROJECT_NAME: Testing


### PR DESCRIPTION
This PR adds a workflow (utilizing solely [https://github.com/peter-evans/create-or-update-project-card](this action)) that will create project cards in the `Testing` project of the repo when a new issue is created, and update them if the issue is edited. Cards will be created in the `To do` column. These values can be changed by updating the `env` property of the workflow.

You can see an example card in the `To do` column [here](https://github.com/slaughtr/lhtlhtp.com/projects/1), and the issue it was created from [here](https://github.com/slaughtr/lhtlhtp.com/issues/2). 

This workflow won't close issues when cards are closed or anything fancy, just creates and updates them.